### PR TITLE
Include /data/media* by default

### DIFF
--- a/tetherback/README.md
+++ b/tetherback/README.md
@@ -143,11 +143,12 @@ List of devices attached
 * Additional options allow exclusion or inclusion of standard partitions:
 
     ```
-    -M, --media           Include /data/media* in TWRP backup
+    -M, --media           Include /data/media* in TWRP backup (deprecated: default behavior)
     -D, --data-cache      Include /data/*-cache in TWRP backup
     -R, --recovery        Include recovery partition in backup
     -C, --cache           Include /cache partition in backup
-    -U, --no-userdata     Omit /data partition from backup
+    -U, --no-userdata     Omit /data partition from backup (implies --no-media)
+    -E, --no-media        Omit /data/media* from TWRP backup
     -S, --no-system       Omit /system partition from backup
     -B, --no-boot         Omit boot partition from backup
     ```

--- a/tetherback/tetherback.py
+++ b/tetherback/tetherback.py
@@ -51,6 +51,7 @@ def parse_args(args=None):
     x.add_argument('-P','--pipe', dest='transport', action='store_const', const=adbxp.pipe_bin,
                    help="ADB shell binary pipe (fast, but probably only works on Linux hosts)")
     g = p.add_argument_group('Backup contents')
+    g.add_argument('-M', '--media', dest='media_deprecated', action='store_true', default=False, help="Include /data/media* in TWRP backup (Deprecated: /data/media* is included by default. Use --no-media to exclude.)")
     g.add_argument('-D', '--data-cache', action='store_true', default=False, help="Include /data/*-cache in TWRP backup")
     g.add_argument('-R', '--recovery', action='store_true', default=False, help="Include recovery partition in backup")
     g.add_argument('-C', '--cache', dest='cache', action='store_true', default=False, help="Include /cache partition in backup")
@@ -303,6 +304,11 @@ def backup_partition(adb, pi, bp, transport, backupdir, verify=True):
 
 def main(args=None):
     p, args = parse_args(args)
+
+    # warn about deprecated options, if passed on command line
+    if args.media_deprecated:
+        p.error("-M/--media is deprecated. /data/media* will be included by default. Use -E/--no-media to exclude.")
+
     adb = AdbWrapper('adb', ('-s',args.specific) if args.specific else ('-d',), debug=(args.verbose > 1))
 
     print('%s v%s' % (p.prog, p.version), file=stderr)

--- a/tetherback/tetherback.py
+++ b/tetherback/tetherback.py
@@ -3,7 +3,7 @@
 # Inspired by https://gist.github.com/inhies/5069663
 #
 # Currently backs up /data, /system, and /boot partitions
-# Excludes /data/media*, just as TWRP does
+# Includes /data/media* by default, unlike TWRP (see issue #35)
 
 import subprocess as sp
 import os, sys, datetime, socket, time, argparse, re
@@ -51,11 +51,11 @@ def parse_args(args=None):
     x.add_argument('-P','--pipe', dest='transport', action='store_const', const=adbxp.pipe_bin,
                    help="ADB shell binary pipe (fast, but probably only works on Linux hosts)")
     g = p.add_argument_group('Backup contents')
-    g.add_argument('-M', '--media', action='store_true', default=False, help="Include /data/media* in TWRP backup")
     g.add_argument('-D', '--data-cache', action='store_true', default=False, help="Include /data/*-cache in TWRP backup")
     g.add_argument('-R', '--recovery', action='store_true', default=False, help="Include recovery partition in backup")
     g.add_argument('-C', '--cache', dest='cache', action='store_true', default=False, help="Include /cache partition in backup")
-    g.add_argument('-U', '--no-userdata', dest='userdata', action='store_false', default=True, help="Omit /data partition from backup")
+    g.add_argument('-U', '--no-userdata', dest='userdata', action='store_false', default=True, help="Omit /data partition from backup (implies --no-media)")
+    g.add_argument('-E', '--no-media', dest='media', action='store_false', default=True, help="Omit /data/media* from TWRP backup")
     g.add_argument('-S', '--no-system', dest='system', action='store_false', default=True, help="Omit /system partition from backup")
     g.add_argument('-B', '--no-boot', dest='boot', action='store_false', default=True, help="Omit boot partition from backup")
     g.add_argument('-X', '--extra', action='append', metavar='NAME', default=[], help="Include extra partition (as a tarball if this partition is mountable and TWRP backup type is chosen, otherwise as raw image)")


### PR DESCRIPTION
Removes `-M` / `--media` flags and replaces them with `-E` / `--no-media` flags.

`-E` chosen instead of `-M` to avoid confusion and issues with scripts, since the new flag's behavior is the exact opposite of the old.

Intended to resolve #35.
