### PR TITLE
Support encrypted userdata

### DIFF
--- a/tetherback/tetherback.py
+++ b/tetherback/tetherback.py
@@ -175,7 +175,7 @@ def build_partmap(adb, mmcblks=None, fstab='/etc/fstab'):
                 standard = partname
 
             if partname == 'userdata' and mountpoint == None and userdata_partinfo != None:
-                # User data encrypted, ger mountable device from fstab
+                # User data encrypted, get mountable device from fstab
                 devname = userdata_partinfo['dev']
                 mountpoint = userdata_partinfo['mnt']
                 fstype = userdata_partinfo['fs']


### PR DESCRIPTION
If userdata partition doesn't have any mountpoint, assume it is encrypted
and set its device name, mount point and fstype according to the corresponding fstab entry.

Tested on my Nexus 5X device.

This is just a simple fix that overwrites mmcblk entry with dm-* device information obtained from the fstab /data entry. Partition size could be read again from the correct /sys/block/dm-*/size file but I assume it is the same. Of course the assumption wouldn't hold if the encrypted filesystem was also compressed.