### PR TITLE
custom adb path as argument

### DIFF
--- a/tetherback/tetherback.py
+++ b/tetherback/tetherback.py
@@ -33,6 +33,7 @@ def parse_args(args=None):
     p.version=__version__
     p.add_argument('--version', action='version')
     p.add_argument('-s', dest='specific', metavar='DEVICE_ID', default=None, help="Specific device ID (shown by adb devices). Default is sole USB-connected device.")
+    p.add_argument('-a', '--adb-path', dest='cust_adb_path', default=None, help='Specify a path to ADB')
     p.add_argument('-o', '--output-path', default=".", help="Set optional output path for backup files.")
     p.add_argument('-N', '--nandroid', action='store_true', help="Make nandroid backup; raw images rather than tarballs for /system and /data partitions (default is TWRP backup)")
     p.add_argument('-0', '--dry-run', action='store_true', help="Just show the partition map and backup plan, then exit.")
@@ -323,7 +324,10 @@ def main(args=None):
     if args.media_deprecated:
         p.error("-M/--media is deprecated. /data/media* will be included by default. Use -E/--no-media to exclude.")
 
-    adb = AdbWrapper('adb', ('-s',args.specific) if args.specific else ('-d',), debug=(args.verbose > 1))
+    if args.cust_adb_path:
+        adb = AdbWrapper(args.cust_adb_path, ('-s',args.specific) if args.specific else ('-d',), debug=(args.verbose > 1))
+    else:
+        adb = AdbWrapper('adb', ('-s',args.specific) if args.specific else ('-d',), debug=(args.verbose > 1))
 
     print('%s v%s' % (p.prog, p.version), file=stderr)
 

--- a/tetherback/tetherback.py
+++ b/tetherback/tetherback.py
@@ -32,8 +32,8 @@ def parse_args(args=None):
     p = argparse.ArgumentParser(description='''Tool to create TWRP and nandroid-style backups of an Android device running TWRP recovery, using adb-over-USB, without touching the device's internal storage or SD card.''')
     p.version=__version__
     p.add_argument('--version', action='version')
+    p.add_argument('-a', '--adb-path', dest='adb_path', default=None, help='Specify a path to ADB')
     p.add_argument('-s', dest='specific', metavar='DEVICE_ID', default=None, help="Specific device ID (shown by adb devices). Default is sole USB-connected device.")
-    p.add_argument('-a', '--adb-path', dest='cust_adb_path', default=None, help='Specify a path to ADB')
     p.add_argument('-o', '--output-path', default=".", help="Set optional output path for backup files.")
     p.add_argument('-N', '--nandroid', action='store_true', help="Make nandroid backup; raw images rather than tarballs for /system and /data partitions (default is TWRP backup)")
     p.add_argument('-0', '--dry-run', action='store_true', help="Just show the partition map and backup plan, then exit.")
@@ -324,8 +324,8 @@ def main(args=None):
     if args.media_deprecated:
         p.error("-M/--media is deprecated. /data/media* will be included by default. Use -E/--no-media to exclude.")
 
-    if args.cust_adb_path:
-        adb = AdbWrapper(args.cust_adb_path, ('-s',args.specific) if args.specific else ('-d',), debug=(args.verbose > 1))
+    if args.adb_path:
+        adb = AdbWrapper(args.adb_path, ('-s',args.specific) if args.specific else ('-d',), debug=(args.verbose > 1))
     else:
         adb = AdbWrapper('adb', ('-s',args.specific) if args.specific else ('-d',), debug=(args.verbose > 1))
 

--- a/tetherback/tetherback.py
+++ b/tetherback/tetherback.py
@@ -32,7 +32,7 @@ def parse_args(args=None):
     p = argparse.ArgumentParser(description='''Tool to create TWRP and nandroid-style backups of an Android device running TWRP recovery, using adb-over-USB, without touching the device's internal storage or SD card.''')
     p.version=__version__
     p.add_argument('--version', action='version')
-    p.add_argument('-a', '--adb-path', dest='adb_path', default=None, help='Specify a path to ADB')
+    p.add_argument('-a', '--adb-path', dest='adb_path', default=None, help='Specify path to ADB binary')
     p.add_argument('-s', dest='specific', metavar='DEVICE_ID', default=None, help="Specific device ID (shown by adb devices). Default is sole USB-connected device.")
     p.add_argument('-o', '--output-path', default=".", help="Set optional output path for backup files.")
     p.add_argument('-N', '--nandroid', action='store_true', help="Make nandroid backup; raw images rather than tarballs for /system and /data partitions (default is TWRP backup)")
@@ -324,10 +324,7 @@ def main(args=None):
     if args.media_deprecated:
         p.error("-M/--media is deprecated. /data/media* will be included by default. Use -E/--no-media to exclude.")
 
-    if args.adb_path:
-        adb = AdbWrapper(args.adb_path, ('-s',args.specific) if args.specific else ('-d',), debug=(args.verbose > 1))
-    else:
-        adb = AdbWrapper('adb', ('-s',args.specific) if args.specific else ('-d',), debug=(args.verbose > 1))
+    adb = AdbWrapper(args.adb_path or 'adb', ('-s',args.specific) if args.specific else ('-d',), debug=(args.verbose > 1))
 
     print('%s v%s' % (p.prog, p.version), file=stderr)
 


### PR DESCRIPTION
issue #60

```
(env) [chris@tp-w520 install]$ tetherback -0 -a /home/chris/Desktop/adb
tetherback v0.9.1
Found ADB version 1.0.40
Using default transfer method: adb exec-out pipe (--exec-out)
Device reports kernel 3.18.31-perf-gdad85f6-dirty
Device reports TWRP version 3.2.0-0
Reading partition map for mmcblk0 (66 partitions)...
  partition map: 100%                                                                                                                                                                                          
Reading partition map for mmcblk0rpmb (0 partitions)...
  partition map: 100%                                                                                                                                                                                          
Reading partition map for mmcblk1 (1 partitions)...
  partition map: N/A%                                                                                                                                                                                          WARNING: partition mmcblk1p1 has no PARTNAME in its uevent file
Please report this issue at https://github.com/dlenski/tetherback/issues
Please post the entire output from tetherback!
  partition map: 100%                                                                                                                                                                                          

Partition map:

BLOCK DEVICE    PARTITION NAME      SIZE (KiB)  MOUNT POINT    FSTYPE
--------------  ----------------  ------------  -------------  --------
mmcblk0p1       board_info                  16
mmcblk0p2       mfg                        256
...
mmcblk0p60      recovery                 65536
mmcblk0p61      cache                   229376  /cache         ext4
mmcblk0p62      system                 3915776  /system        ext4
dm-0            userdata              25657344  /data          ext4
mmcblk0p64      apppreload               61440  /preload       ext4
mmcblk0p65      cota                     61440  /cota          ext4
mmcblk0p66      absolute                 16384
mmcblk1p1       mmcblk1p1             31165952  /external_sd   vfat
                Total:                61697519

Backup plan:

PARTITION NAME    FILENAME         FORMAT
----------------  ---------------  ------------------------------
boot              boot.emmc.win    gzipped raw image
system            system.ext4.win  tar -cz -p
userdata          data.ext4.win    tar -cz -p --exclude="*-cache"
```

edit: output