### PR TITLE
Ensure that value sent to progressbar is always in range

### DIFF
--- a/tetherback/tetherback.py
+++ b/tetherback/tetherback.py
@@ -296,7 +296,7 @@ def backup_partition(adb, pi, bp, transport, backupdir, verify=True):
             out.write(block)
             if verify:
                 localmd5.update(block)
-            pbar.update(out.tell())
+            pbar.update(min(out.tell(), pbar.max_value))
         else:
             pbar.max_value = out.tell() or pbar.max_value # need to adjust for the smaller compressed size
             pbar.finish()


### PR DESCRIPTION
This fixes the initial problem described in https://github.com/dlenski/tetherback/issues/50, which is that because the max_value of the progressbar is set based on the size of the uncompressed file, but the progress of the progressbar is set based on how many bytes of the *compressed* file have been received, that means that in certain cases the progress can be larger than the max_value, which causes progressbar to throw an exception.  (Notably, I have noticed this commonly happening for partitions that are very small, or for partitions that contain encrypted data.)

This fixes the exception by simply clamping the progress value to the max_value to ensure that we don't cause progressbar to crash.  I had several partitions on my Nexus 5X that had this problem and that now correctly transfer with this fix.