### PR TITLE
Fixed version check from working in inverse, as it is: !(x < 3.6)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import sys, os, re, subprocess as sp
 from setuptools import setup
 
-if not sys.version_info < (3, 6):
+if sys.version_info < (3, 6):
     sys.exit("Python 3.6 or newer is required.")
 
 ########################################


### PR DESCRIPTION
Current version was:
if not sys.version_info < (3, 6) -> exit
let's test this:
Ex. 1
	sys.version_info = (3, 5)
	sys.version_info < (3, 6) ? true
	not sys.version_info < (3, 6) ? false -> try continuing the installation as normal
Ex. 2
	sys.version_info = (3, 10)
	sys.version_info < (3, 6) ? false
	not sys.version_info < (3, 6) ? true -> exit, error message "Python 3.6 or newer is required"
If 3.6 or newer is required, the 'not' in the check is breaking it. Admittedly, most users probably stay on the release version. Still, this shouldn't be so obviously and easily fixable imo.